### PR TITLE
Added upper bound on dimensional package.

### DIFF
--- a/lambda-devs.cabal
+++ b/lambda-devs.cabal
@@ -56,7 +56,7 @@ Test-suite lambda-devs-tests
                        binary >=0.5, 
                        containers >=0.5, 
                        distributed-process >=0.4,
-                       dimensional >= 0.12  
+                       dimensional >= 0.12 && < 0.14
   default-language:    Haskell2010
   ghc-options:         -Wall 
   other-extensions:    MultiParamTypeClasses,


### PR DESCRIPTION
We are intending to release a new version of the dimensional package based on the design in the yet-unreleased dimensional-dk package which uses data kinds and closed type families to provide additional assurances. As part of the migration strategy we are encouraging people with dependencies on dimensional to add upper bounds.
